### PR TITLE
changed YamlConfig to use ruamel.yaml instead of yaml

### DIFF
--- a/autolab_core/yaml_config.py
+++ b/autolab_core/yaml_config.py
@@ -3,7 +3,7 @@ YAML Configuration Parser
 Author : Jeff Mahler
 """
 import os
-import yaml
+import ruamel.yaml as yaml
 import re
 from collections import OrderedDict
 
@@ -127,4 +127,3 @@ class YamlConfig(object):
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             lambda loader, node: object_pairs_hook(loader.construct_pairs(node)))
         return yaml.load(stream, OrderedLoader)
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 requirements = [
     'numpy',
     'scipy',
-    'pyyaml',
+    'ruamel.yaml',
     'matplotlib',
     'multiprocess',
     'setproctitle',
@@ -51,4 +51,3 @@ setup(
                         ],
     }
 )
-


### PR DESCRIPTION
This enables compliance w/ YAML 1.2 instead of YAML 1.1, and allows reading numbers in scientific notations