### PR TITLE
Changed logging to use root logger.

### DIFF
--- a/autolab_core/__init__.py
+++ b/autolab_core/__init__.py
@@ -15,6 +15,7 @@ from .random_variables import RandomVariable, BernoulliRV, GaussianRV, Artificia
 from .completer import Completer
 from .learning_analysis import ConfusionMatrix, ClassificationResult, BinaryClassificationResult, RegressionResult
 from .tensor_dataset import Tensor, TensorDatapoint, TensorDataset
+from .logger import Logger
 
 try:
     from .data_stream_syncer import DataStreamSyncer

--- a/autolab_core/logger.py
+++ b/autolab_core/logger.py
@@ -118,3 +118,26 @@ class Logger(object):
         if no_op:
             logger.addHandler(logging.NullHandler())
         return logger
+
+    @staticmethod
+    def add_log_file(logger, log_file, global_log_file=False):
+        """
+        Add a log file to this logger. If global_log_file is true, log_file will be handed the root logger, otherwise it will only be used by this particular logger.
+
+        Parameters
+        ----------
+        logger :obj:`logging.Logger`
+            The logger.
+        log_file :obj:`str`
+            The path to the log file to log to.
+        global_log_file :obj:`bool`
+            Whether or not to use the given log_file for this particular logger or for the root logger.
+        """
+
+        if global_log_file:
+            add_root_log_file(log_file)
+        else:
+            hdlr = logging.FileHandler(log_file)
+            formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M:%S')
+            hdlr.setFormatter(formatter)
+            logger.addHandler(hdlr)

--- a/autolab_core/logger.py
+++ b/autolab_core/logger.py
@@ -1,0 +1,103 @@
+"""
+Utility class for logging.
+
+Author: Vishal Satish
+"""
+import logging
+import sys
+
+import colorlog
+
+ROOT_LOG_LEVEL = logging.INFO
+ROOT_LOG_STREAM = sys.stdout
+
+def configure_root():
+    """Configure the root logger."""
+    root_logger = logging.getLogger()
+
+    # clear any existing handles to streams because we don't want duplicate logs
+    # NOTE: we assume that any stream handles we find are to ROOT_LOG_STREAM, which is usually the case(because it is stdout). This is fine because we will be re-creating that handle. Otherwise we might be deleting a handle that won't be re-created, which could result in dropped logs.
+    for hdlr in root_logger.handlers:
+        if isinstance(hdlr, logging.StreamHandler):
+            root_logger.removeHandler(hdlr)
+
+    # configure the root logger
+    root_logger.setLevel(ROOT_LOG_LEVEL)
+    hdlr = logging.StreamHandler(ROOT_LOG_STREAM) 
+    formatter = colorlog.ColoredFormatter(
+                        '%(purple)s%(name)-10s %(log_color)s%(levelname)-8s%(reset)s %(white)s%(message)s',
+                        reset=True,
+                        log_colors={
+                            'DEBUG': 'cyan',
+                            'INFO': 'green',
+                            'WARNING': 'yellow',
+                            'ERROR': 'red',
+                            'CRITICAL': 'red,bg_white',
+                        } 
+                                         )   
+    hdlr.setFormatter(formatter)
+    root_logger.addHandler(hdlr)
+
+def add_root_log_file(log_file):
+    """
+    Add a log file to the root logger.
+
+    Parameters
+    ----------
+    log_file :obj:`str`
+        The path to the log file.
+    """
+    root_logger = logging.getLogger()
+
+    # add a file handle to the root logger
+    hdlr = logging.FileHandler(log_file)
+    formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M:%S')
+    hdlr.setFormatter(formatter)
+    root_logger.addHandler(hdlr)
+    root_logger.info('Root logger now logging to {}'.format(log_file))
+
+class Logger(object):
+    ROOT_CONFIGURED = False
+
+    @staticmethod
+    def get_logger(name, log_level=logging.INFO, log_file=None, global_log_file=False):
+        """
+        Build a logger. All logs will be propagated up to the root logger. If log_file is provided, logs will be written out to that file. If global_log_file is true, log_file will be used by the root logger, otherwise it will only be used by this particular logger.
+    
+        Parameters
+        ----------
+        name :obj:`str`
+            The name of the logger to be built.
+        log_level : `int`
+            The log level. See the python logging module documentation for possible enum values.
+        log_file :obj:`str`
+            The path to the log file to log to.
+        global_log_file :obj:`bool`
+            Whether or not to use the given log_file for this particular logger or for the root logger.
+
+        Returns
+        -------
+        :obj:`logging.Logger`
+            A custom logger.
+        """
+        # configure the root logger if it hasn't been already
+        if not Logger.ROOT_CONFIGURED:
+            configure_root()
+        Logger.ROOT_CONFIGURED = True
+        
+        # build a logger
+        logger = logging.getLogger(name)
+        logger.setLevel(log_level)
+
+        # configure the log file stream 
+        if log_file is not None:
+            # if the log file is global, add it to the root logger
+            if global_log_file:
+                add_root_log_file(log_file)
+            # otherwise add it to this particular logger
+            else:
+                hdlr = logging.FileHandler(log_file)
+                formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M:%S')
+                hdlr.setFormatter(formatter)
+                logger.addHandler(hdlr)
+        return logger

--- a/autolab_core/logger.py
+++ b/autolab_core/logger.py
@@ -60,9 +60,9 @@ class Logger(object):
     ROOT_CONFIGURED = False
 
     @staticmethod
-    def get_logger(name, log_level=logging.INFO, log_file=None, global_log_file=False):
+    def get_logger(name, log_level=logging.INFO, log_file=None, global_log_file=False, silence=False):
         """
-        Build a logger. All logs will be propagated up to the root logger. If log_file is provided, logs will be written out to that file. If global_log_file is true, log_file will be used by the root logger, otherwise it will only be used by this particular logger.
+        Build a logger. All logs will be propagated up to the root logger if not silenced. If log_file is provided, logs will be written out to that file. If global_log_file is true, log_file will be handed the root logger, otherwise it will only be used by this particular logger.
     
         Parameters
         ----------
@@ -74,6 +74,8 @@ class Logger(object):
             The path to the log file to log to.
         global_log_file :obj:`bool`
             Whether or not to use the given log_file for this particular logger or for the root logger.
+        silence :obj:`bool`
+            Whether or not to silence this logger. If it is silenced, the only way to get output from this logger is through a non-global log file.
 
         Returns
         -------
@@ -88,6 +90,11 @@ class Logger(object):
         # build a logger
         logger = logging.getLogger(name)
         logger.setLevel(log_level)
+
+        # silence the logger by preventing it from propagating upwards to the root
+        logger.propagate = not silence
+        if silence and global_log_file:
+            logging.warning('You have created a logger with no method of logging!')
 
         # configure the log file stream 
         if log_file is not None:

--- a/autolab_core/logger.py
+++ b/autolab_core/logger.py
@@ -82,6 +82,14 @@ class Logger(object):
         :obj:`logging.Logger`
             A custom logger.
         """
+        no_op = False
+        # some checks for silencing/no-op logging
+        if silence and global_log_file:
+            raise ValueError("You can't silence a logger and log to a global log file!")
+        if silence and log_file is None:
+            logging.warning('You are creating a no-op logger!')
+            no_op = True
+
         # configure the root logger if it hasn't been already
         if not Logger.ROOT_CONFIGURED:
             configure_root()
@@ -93,8 +101,6 @@ class Logger(object):
 
         # silence the logger by preventing it from propagating upwards to the root
         logger.propagate = not silence
-        if silence and global_log_file:
-            logging.warning('You have created a logger with no method of logging!')
 
         # configure the log file stream 
         if log_file is not None:
@@ -107,4 +113,8 @@ class Logger(object):
                 formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M:%S')
                 hdlr.setFormatter(formatter)
                 logger.addHandler(hdlr)
+
+        # add a no-op handler to suppress warnings about there being no handlers
+        if no_op:
+            logger.addHandler(logging.NullHandler())
         return logger

--- a/autolab_core/utils.py
+++ b/autolab_core/utils.py
@@ -5,68 +5,7 @@ Author: Jeff Mahler
 import logging
 import os
 
-import colorlog
 import numpy as np
-
-def clear_root_logger():
-    """Clear the root logger's handlers, allowing for full control over logging."""
-    for hdlr in logging.getLogger().handlers:
-        logging.getLogger().removeHandler(hdlr)
-
-def get_logger(name, log_file=None, log_stream=None, log_level=logging.INFO):
-    """Build a custom logger. If neither a log file nor log stream is provided, a no-op logger will be returned.
-
-    Parameters
-    ----------
-    name :obj:`str`
-        The name of the logger to be built.
-    log_file :obj:`str`
-        The path to the log file to log to.
-    log_stream :obj:`file`
-        The file stream to log to.
-
-    Returns
-    -------
-    :obj:`logging.Logger`
-        A custom logger. 
-    """
-
-    # clear the root logger's handlers
-    clear_root_logger()
-
-    # create the logger and set the logging level
-    logger = logging.getLogger(name)
-    logger.setLevel(log_level)
-
-    # set up handlers    
-    if log_file is not None:
-        # set up log file handler
-        hdlr = logging.FileHandler(log_file)
-        formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M:%S')
-        hdlr.setFormatter(formatter)
-        logger.addHandler(hdlr)
-    if log_stream is not None:
-        # set up log stream handler with colorful logging
-        hdlr = logging.StreamHandler(log_stream)
-        formatter = colorlog.ColoredFormatter(
-                            '%(purple)s%(name)-10s %(log_color)s%(levelname)-8s%(reset)s %(white)s%(message)s',
-                            reset=True,
-                            log_colors={
-                                'DEBUG': 'cyan',
-                                'INFO': 'green',
-                                'WARNING': 'yellow',
-                                'ERROR': 'red',
-                                'CRITICAL': 'red,bg_white',
-                            },
-                                            )
-        hdlr.setFormatter(formatter)
-        logger.addHandler(hdlr)
-
-    if len(logger.handlers) == 0:
-        # if no handlers were added, add the NullHandler to squelch output complaining about no handlers
-        logger.addHandler(logging.NullHandler())
-
-    return logger
 
 def gen_experiment_id(n=10):
     """Generate a random string with n characters.


### PR DESCRIPTION
@jeffmahler This is the new proposed logging scheme that utilizes the root logger. Let me know if you have any suggestions. Note line 19 in logger.py. Basically the issue is that on configuration we want to change the formatter of the root logger's handle to stdout, and create/initialize one if a handler does not exist. However, there is no way afaik to get the stream of a particular handler. Then it gets kinda messy because we can't tell if one exists already, and we don't want to have duplicates. The current solution should work in our use cases, but would break if someone had a handle on the root logger to some other output stream like stderr.