### PR TITLE
Remove unnecessary warning for Data Stream classes

### DIFF
--- a/autolab_core/__init__.py
+++ b/autolab_core/__init__.py
@@ -16,9 +16,5 @@ from .completer import Completer
 from .learning_analysis import ConfusionMatrix, ClassificationResult, BinaryClassificationResult, RegressionResult
 from .tensor_dataset import Tensor, TensorDatapoint, TensorDataset
 from .logger import Logger
-
-try:
-    from .data_stream_syncer import DataStreamSyncer
-    from .data_stream_recorder import DataStreamRecorder
-except Exception:
-    print("Unable to import DataStreamSyncer and Recorder! Likely due to missing multiprocess")
+from .data_stream_syncer import DataStreamSyncer
+from .data_stream_recorder import DataStreamRecorder

--- a/autolab_core/data_stream_syncer.py
+++ b/autolab_core/data_stream_syncer.py
@@ -4,7 +4,10 @@ Author: Jacky Liang
 """
 from multiprocess import Process, Queue
 from time import time
-from Queue import Empty
+try:
+    from Queue import Empty
+except:
+    from queue import Empty
 import logging, sys
 from setproctitle import setproctitle
 


### PR DESCRIPTION
- For DataStreamSyncer, added case for importing "queue" if "Queue" doesn't work. The uppercase is Python 2, while lowercase is Python 3.

- Removed unneeded try/except statement in __init__.py regarding Data Stream classes, as all the dependencies they require are in setup.py