### PR TITLE
more efficient rigid transform inverse

### DIFF
--- a/autolab_core/rigid_transformations.py
+++ b/autolab_core/rigid_transformations.py
@@ -452,7 +452,7 @@ class RigidTransform(object):
         if isinstance(rigid_object, BagOfPoints):
             return self.apply(rigid_object)
         raise ValueError('Cannot multiply rigid transform with object of type %s' %(type(rigid_object)))
-
+                              
     def inverse(self):
         """Take the inverse of the rigid transform.
 
@@ -461,9 +461,9 @@ class RigidTransform(object):
         :obj:`RigidTransform`
             The inverse of this RigidTransform.
         """
-        inv_pose = np.linalg.inv(self.matrix)
-        rotation, translation = RigidTransform.rotation_and_translation_from_matrix(inv_pose)
-        return RigidTransform(rotation, translation,
+        inv_rotation = self.rotation.T
+        inv_translation = np.dot(-self.rotation.T, self.translation)
+        return RigidTransform(inv_rotation, inv_translation,
                               from_frame=self._to_frame,
                               to_frame=self._from_frame)
 


### PR DESCRIPTION
Ran the following for testing accuracy/speed of each method (inverse() is current inverse method, inverse2() is proposed method):

```
import numpy as np
import timeit
from autolab_core import RigidTransform

loops = 10000
print('inverse(), {} loops: {:.6f} s per loop'.format(loops,
      timeit.timeit('RigidTransform(rotation=RigidTransform.random_rotation(), translation=RigidTransform.random_translation()).inverse()', 
      setup="from __main__ import RigidTransform", number=loops)/loops))
print('inverse2(), {} loops: {:.6f} s per loop'.format(loops,
      timeit.timeit('RigidTransform(rotation=RigidTransform.random_rotation(), translation=RigidTransform.random_translation()).inverse2()', 
      setup="from __main__ import RigidTransform", number=loops)/loops))

same = np.zeros(loops, dtype=np.uint8)
for i in range(loops):
    A = RigidTransform(rotation=RigidTransform.random_rotation(), translation=RigidTransform.random_translation())
    same[i] = np.allclose(A.inverse().matrix, A.inverse2().matrix)

print(np.all(same))
```

Here is the output:
```
inverse() 10000 loops: 0.000129 s per loop
inverse2() 10000 loops: 0.000063 s per loop
True
```