### PR TITLE
fix so that yaml prints in readable fashion

### DIFF
--- a/autolab_core/yaml_config.py
+++ b/autolab_core/yaml_config.py
@@ -92,7 +92,7 @@ class YamlConfig(object):
         def recursive_load(matchobj, path):
             first_spacing = matchobj.group(1)
             other_spacing = first_spacing.replace('-', ' ')
-            fname = os.path.join(path, matchobj.group(2))
+            fname = os.path.join(path, matchobj.group(2).rstrip())
             new_path, _ = os.path.split(fname)
             new_path = os.path.realpath(new_path)
             text = ''

--- a/autolab_core/yaml_config.py
+++ b/autolab_core/yaml_config.py
@@ -70,7 +70,8 @@ class YamlConfig(object):
 
     def save(self, filename):
         """ Save a YamlConfig to disk. """
-        yaml.dump(self, open(filename, 'w'))
+        y = yaml.YAML()
+        y.dump(self.config, open(filename, 'w'))
 
     def _load_config(self, filename):
         """Loads a yaml configuration file from the given filename.


### PR DESCRIPTION
Loading the saved file is the same; this is literally so I can read dataset generation params more easily. Also, added a quick fix for the recursive loading which avoids failure if there is extra spacing after the !include statements (often happens with comments).