### PR TITLE
Fixed catkin package version from 0.10 to 0.12.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>autolab_core</name>
-  <version>0.0.10</version>
+  <version>0.0.12</version>
   <description>The autolab_core package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 


### PR DESCRIPTION
Currently the version.py is on 0.12 while the package.xml is still on 0.10. While building the package with catkin I therfore get the following error:

```
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_python_setup.cmake:79 (message):               
  catkin_python_setup() version in setup.py (0.0.12) differs from version in                             │
  package.xml (0.0.10)
```

Maybe this behavior is intended but I had to change it in order to use the package.