### PR TITLE
Remove matplotlib version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     'scipy',
     'scikit-learn',
     'ruamel.yaml',
-    'matplotlib<=2.2.0',
+    'matplotlib',
     'multiprocess',
     'setproctitle',
     'joblib',


### PR DESCRIPTION
There are only 3 instances where matplotlib is used, and those calls do not rely on the specific version requirement.

Removing the version requirement prevents installation errors when the user has a newer matplotlib version. This is common because the latest matplotlib is 3.2.1.